### PR TITLE
Limit build arches

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -12,6 +12,11 @@ adopt-info: wethr
 grade: stable
 confinement: strict
 
+architectures:
+  - build-on: amd64
+  - build-on: armhf
+  - build-on: arm64
+
 apps:
   wethr:
     command: wethr


### PR DESCRIPTION
Node no longer makes x86 binaries so we don't build for that now.